### PR TITLE
update compileSdkVersion+buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,8 +15,8 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Old CompileSdk and BulidTool lead to error 

```
> Task :react-native-upi-payment:verifyReleaseResources FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-upi-payment:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > Android resource linking failed
```